### PR TITLE
Add steps to publish to GitCode

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -111,9 +111,10 @@ jobs:
       - name: Check if Release exists on GitCode
         id: check_release
         run: |
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+          RESPONSE=$(curl -L -sS -o /dev/null -w "%{http_code}" \
+            -H 'PRIVATE-TOKEN: ${{ secrets.GITCODE_TOKEN }}' \
             -H "Accept: application/json" \
-            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/tags/${{ env.TAG_NAME }}?access_token=${{ secrets.GITCODE_TOKEN }}")
+            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/tags/${{ env.TAG_NAME }}")
           if [ "$RESPONSE" = "200" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "Release already exists on GitCode"
@@ -126,8 +127,9 @@ jobs:
         id: create_release
         run: |
           echo "Creating new release on GitCode..."
-          RESPONSE=$(curl -s -w "%{http_code}" -o response.json \
+          RESPONSE=$(curl -L -o response.json -sS -w "%{http_code}" \
             -X POST \
+            -H 'PRIVATE-TOKEN: ${{ secrets.GITCODE_TOKEN }}' \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
             -d '{
@@ -150,8 +152,9 @@ jobs:
         id: update_release
         run: |
           echo "Updating existing release on GitCode..."
-          RESPONSE=$(curl -s -w "%{http_code}" -o response.json \
+          RESPONSE=$(curl -L -o response.json -sS -w "%{http_code}" \
             -X PATCH \
+            -H 'PRIVATE-TOKEN: ${{ secrets.GITCODE_TOKEN }}' \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
             -d '{
@@ -172,9 +175,10 @@ jobs:
         run: |
           for file in *.nvda-addon; do
             echo "Uploading $file..."
-            UPLOAD_INFO=$(curl -s \
+            UPLOAD_INFO=$(curl -sS \
+              -H 'PRIVATE-TOKEN: ${{ secrets.GITCODE_TOKEN }}' \
               -H "Accept: application/json" \
-              "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/${{ env.TAG_NAME }}/upload_url?access_token=${{ secrets.GITCODE_TOKEN }}&file_name=$file")
+              "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/${{ env.TAG_NAME }}/upload_url?file_name=$file")
             UPLOAD_URL=$(echo "$UPLOAD_INFO" | jq -r '.url')
             CURL_HEADERS=()
             HEADERS_JSON=$(echo "$UPLOAD_INFO" | jq -r '.headers // empty')
@@ -185,7 +189,7 @@ jobs:
                 fi
               done < <(echo "$HEADERS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value)"')
             fi
-            RESPONSE=$(curl -X PUT -w "%{http_code}" -o "$file.response.json" \
+            RESPONSE=$(curl -X PUT -w "%{http_code}" -o "$file.response.json" --retry 3 \
               -T "$file" \
               "${CURL_HEADERS[@]}" \
               "$UPLOAD_URL")

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -139,7 +139,7 @@ jobs:
               "body": "${{ env.TAG_NAME }}",
               "prerelease": '${{ contains(github.ref, '-') }}'
             }' \
-            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases?access_token=${{ secrets.GITCODE_TOKEN }}")
+            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases")
           if [ "$RESPONSE" = "200" ]; then
             echo "✅ Release created successfully on GitCode"
           else
@@ -163,7 +163,7 @@ jobs:
               "body": "${{ env.TAG_NAME }}",
               "prerelease": '${{ contains(github.ref, '-') }}'
             }' \
-            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/${{ env.TAG_NAME }}?access_token=${{ secrets.GITCODE_TOKEN }}")
+            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/${{ env.TAG_NAME }}")
           if [ "$RESPONSE" = "200" ]; then
             echo "✅ Release updated successfully on GitCode"
           else

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -185,8 +185,15 @@ jobs:
                 fi
               done < <(echo "$HEADERS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value)"')
             fi
-              curl -X PUT \
+            RESPONSE=$(curl -X PUT -w "%{http_code}" -o "$file.response.json" \
               -T "$file" \
               "${CURL_HEADERS[@]}" \
-              "$UPLOAD_URL"
+              "$UPLOAD_URL")
+            if [ "$RESPONSE" -ne 200 ]; then
+              echo "❌ Failed to upload $file. Response code: $RESPONSE"
+              cat "$file.response.json"
+              exit 1
+            else
+              echo "✅ Uploaded $file successfully"
+            fi
           done

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -11,6 +11,9 @@ on:
 
   workflow_dispatch:
 
+env:
+  GITCODE_REPOSITORY: ${{ vars.GITCODE_REPOSITORY || github.repository }}
+
 jobs:
   build:
 
@@ -73,3 +76,117 @@ jobs:
         body_path: changelog.md
         fail_on_unmatched_files: true
         prerelease: ${{ contains(github.ref, '-') }}
+
+  push_to_gitcode:
+    name: Push to GitCode
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') && vars.GITCODE_USERNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: master
+      - name: Push to GitCode
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions@github.com"
+          git remote add gitcode https://${{ vars.GITCODE_USERNAME }}:${{ secrets.GITCODE_TOKEN }}@gitcode.com/${{ env.GITCODE_REPOSITORY }}.git
+          git push gitcode --tags --force master:master
+
+  gitcode_release:
+    name: Create Release on GitCode
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - push_to_gitcode
+    env:
+      TAG_NAME: ${{ github.ref_name }}
+    steps:
+      - name: Download Archive
+        uses: actions/download-artifact@v6
+        with:
+          name: packaged_addon
+          path: .
+      - name: Check if Release exists on GitCode
+        id: check_release
+        run: |
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Accept: application/json" \
+            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/tags/${{ env.TAG_NAME }}?access_token=${{ secrets.GITCODE_TOKEN }}")
+          if [ "$RESPONSE" = "200" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release already exists on GitCode"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Release does not exist on GitCode"
+          fi
+      - name: Create Release on GitCode
+        if: steps.check_release.outputs.exists == 'false'
+        id: create_release
+        run: |
+          echo "Creating new release on GitCode..."
+          RESPONSE=$(curl -s -w "%{http_code}" -o response.json \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -d '{
+              "tag_name": "'"${{ env.TAG_NAME }}"'",
+              "target_commitish": "master",
+              "name": "${{ env.TAG_NAME }}",
+              "body": "${{ env.TAG_NAME }}",
+              "prerelease": '${{ contains(github.ref, '-') }}'
+            }' \
+            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases?access_token=${{ secrets.GITCODE_TOKEN }}")
+          if [ "$RESPONSE" = "200" ]; then
+            echo "✅ Release created successfully on GitCode"
+          else
+            echo "❌ Failed to create release. Response code: $RESPONSE"
+            cat response.json
+            exit 1
+          fi
+      - name: Update Release on GitCode
+        if: steps.check_release.outputs.exists == 'true'
+        id: update_release
+        run: |
+          echo "Updating existing release on GitCode..."
+          RESPONSE=$(curl -s -w "%{http_code}" -o response.json \
+            -X PATCH \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -d '{
+              "tag_name": "'"${{ env.TAG_NAME }}"'",
+              "name": "${{ env.TAG_NAME }}",
+              "body": "${{ env.TAG_NAME }}",
+              "prerelease": '${{ contains(github.ref, '-') }}'
+            }' \
+            "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/${{ env.TAG_NAME }}?access_token=${{ secrets.GITCODE_TOKEN }}")
+          if [ "$RESPONSE" = "200" ]; then
+            echo "✅ Release updated successfully on GitCode"
+          else
+            echo "❌ Failed to update release. Response code: $RESPONSE"
+            cat response.json
+            exit 1
+          fi
+      - name: Upload Build Artifacts to Release
+        run: |
+          for file in *.nvda-addon; do
+            echo "Uploading $file..."
+            UPLOAD_INFO=$(curl -s \
+              -H "Accept: application/json" \
+              "https://api.gitcode.com/api/v5/repos/${{ env.GITCODE_REPOSITORY }}/releases/${{ env.TAG_NAME }}/upload_url?access_token=${{ secrets.GITCODE_TOKEN }}&file_name=$file")
+            UPLOAD_URL=$(echo "$UPLOAD_INFO" | jq -r '.url')
+            CURL_HEADERS=()
+            HEADERS_JSON=$(echo "$UPLOAD_INFO" | jq -r '.headers // empty')
+            if [ -n "$HEADERS_JSON" ] && [ "$HEADERS_JSON" != "null" ]; then
+              while IFS='' read -r line; do
+                if [ -n "$line" ]; then
+                  CURL_HEADERS+=("-H" "$line")
+                fi
+              done < <(echo "$HEADERS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value)"')
+            fi
+              curl -X PUT \
+              -T "$file" \
+              "${CURL_HEADERS[@]}" \
+              "$UPLOAD_URL"
+          done


### PR DESCRIPTION
添加发布到 GitCode 的步骤，以便通过 GitHub 下载缓慢的用户可流畅下载该插件。
合并该 PR 前需要的准备工作：
- 添加 repository secret，名称：GITCODE_TOKEN，值：GitCode 访问令牌
- 添加repository variable，名称：GITCODE_USERNAME，值：提供 GitCode 访问令牌的 GitCode 用户名
- 添加repository variable（可选），名称：GITCODE_REPOSITORY，值：nvdacn/AiSound5