### PR TITLE
Enhance AiSound callback tracking and stabilize waveOut hooks

### DIFF
--- a/addon/synthDrivers/aisound/_aisound.py
+++ b/addon/synthDrivers/aisound/_aisound.py
@@ -134,6 +134,28 @@ def ensureWaveOutHooks(dllPath):
 		_waveOutHooks.append(FunctionHooker(dllPath,"WINMM.dll","waveOutClose",waveOutClose))
 
 
+def _handle_utterance_end(token):
+	"""Handles cleanup for an utterance. Must be called with _stateLock held."""
+	global isPlaying
+	gen = _tokenToGeneration.pop(token, None)
+	_tokenToIndex.pop(token, None)
+
+	if gen is not None:
+		# Utterance was found, decrement pending count for its generation.
+		remaining = _generationPending.get(gen, 0)
+		if remaining > 1:
+			_generationPending[gen] = remaining - 1
+		elif remaining == 1:
+			_generationPending.pop(gen, None)
+
+	# Always update isPlaying to reflect the current state for robustness.
+	currentPending = _generationPending.get(_currentGeneration, 0)
+	isPlaying = currentPending > 0
+
+	# Notify only if the utterance was from the current generation and it was the last one.
+	return gen is not None and gen == _currentGeneration and currentPending == 0
+
+
 @aisound_callback_t
 def callback(type,cbData):
 	global lastIndex,isPlaying,synthRef
@@ -152,19 +174,7 @@ def callback(type,cbData):
 		with _stateLock:
 			if token is None:
 				return
-			gen = _tokenToGeneration.pop(token, None)
-			_tokenToIndex.pop(token, None)
-			if gen is None:
-				# stale callback from canceled/cleared state
-				return
-			remaining = _generationPending.get(gen, 0)
-			if remaining > 1:
-				_generationPending[gen] = remaining - 1
-			elif remaining == 1:
-				_generationPending.pop(gen, None)
-			currentPending = _generationPending.get(_currentGeneration, 0)
-			isPlaying = currentPending > 0
-			shouldNotify = (gen == _currentGeneration and currentPending == 0)
+			shouldNotify = _handle_utterance_end(token)
 		if shouldNotify:
 			synthDoneSpeaking.notify(synth=synthRef())
 
@@ -214,17 +224,7 @@ def Speak(text,index=None):
 	if not ok:
 		shouldNotify=False
 		with _stateLock:
-			failGen = _tokenToGeneration.pop(token, None)
-			_tokenToIndex.pop(token, None)
-			if failGen is not None:
-				remaining = _generationPending.get(failGen, 0)
-				if remaining > 1:
-					_generationPending[failGen] = remaining - 1
-				elif remaining == 1:
-					_generationPending.pop(failGen, None)
-			currentPending = _generationPending.get(_currentGeneration, 0)
-			isPlaying = currentPending > 0
-			shouldNotify = (failGen == _currentGeneration and currentPending == 0)
+			shouldNotify = _handle_utterance_end(token)
 		if shouldNotify:
 			synthDoneSpeaking.notify(synth=synthRef())
 	return ok

--- a/addon/synthDrivers/aisound/_aisound.py
+++ b/addon/synthDrivers/aisound/_aisound.py
@@ -2,6 +2,7 @@
 #A part of NVDA AiSound 5 Synthesizer Add-On
 
 import os
+import threading
 import weakref
 import audioDucking
 from ctypes import *
@@ -21,6 +22,12 @@ wrapperDLL=None
 lastIndex=None
 isPlaying=False
 synthRef=None
+_currentGeneration=0
+_nextCbToken=1
+_tokenToGeneration={}
+_tokenToIndex={}
+_generationPending={}
+_stateLock=threading.Lock()
 
 aisound_callback_t=CFUNCTYPE(None,c_int,c_void_p)
 SPEECH_BEGIN=0
@@ -91,6 +98,14 @@ _duckersByHandle={}
 
 @WINFUNCTYPE(windll.winmm.waveOutOpen.restype,*windll.winmm.waveOutOpen.argtypes,use_errno=False,use_last_error=False)
 def waveOutOpen(pWaveOutHandle,deviceID,wfx,callback,callbackInstance,flags):
+	# Normalize callback pointers to the current winmm argtypes. This avoids
+	# ctypes rejecting equivalent pointer types when the module has been reloaded.
+	expected_handle_type = windll.winmm.waveOutOpen.argtypes[0]
+	expected_wfx_type = windll.winmm.waveOutOpen.argtypes[2]
+	if pWaveOutHandle:
+		pWaveOutHandle = cast(pWaveOutHandle, expected_handle_type)
+	if wfx:
+		wfx = cast(wfx, expected_wfx_type)
 	try:
 		res=windll.winmm.waveOutOpen(pWaveOutHandle,deviceID,wfx,callback,callbackInstance,flags) or 0
 	except WindowsError as e:
@@ -122,15 +137,36 @@ def ensureWaveOutHooks(dllPath):
 @aisound_callback_t
 def callback(type,cbData):
 	global lastIndex,isPlaying,synthRef
+	token = int(cbData) if cbData else None
 	if type==SPEECH_BEGIN:
-		if cbData==None:
+		if token is None:
 			lastIndex=0
-		else:
-			lastIndex=cbData
+			return
+		with _stateLock:
+			index = _tokenToIndex.get(token)
+		if index is not None:
+			lastIndex=index
 			synthIndexReached.notify(synth=synthRef(),index=lastIndex)
 	elif type==SPEECH_END:
-		isPlaying=False
-		synthDoneSpeaking.notify(synth=synthRef())
+		shouldNotify=False
+		with _stateLock:
+			if token is None:
+				return
+			gen = _tokenToGeneration.pop(token, None)
+			_tokenToIndex.pop(token, None)
+			if gen is None:
+				# stale callback from canceled/cleared state
+				return
+			remaining = _generationPending.get(gen, 0)
+			if remaining > 1:
+				_generationPending[gen] = remaining - 1
+			elif remaining == 1:
+				_generationPending.pop(gen, None)
+			currentPending = _generationPending.get(_currentGeneration, 0)
+			isPlaying = currentPending > 0
+			shouldNotify = (gen == _currentGeneration and currentPending == 0)
+		if shouldNotify:
+			synthDoneSpeaking.notify(synth=synthRef())
 
 def Initialize(synth: weakref.ReferenceType):
 	global wrapperDLL,isPlaying,synthRef
@@ -161,17 +197,46 @@ def Configure(name,value):
 	return wrapperDLL.aisound_configure(name.encode("utf-8"),value.encode("utf-8"))
 
 def Speak(text,index=None):
-	global wrapperDLL,isPlaying
-	if index==None:
-		cbData=0
-	else:
-		cbData=index
-	isPlaying=True
-	return wrapperDLL.aisound_speak(text.encode("utf-8"),c_void_p(cbData))
+	global wrapperDLL,isPlaying,_nextCbToken
+	with _stateLock:
+		token = _nextCbToken
+		_nextCbToken += 1
+		# c_void_p(0) becomes None on callback; keep token non-zero.
+		if _nextCbToken > 0x7FFFFFFF:
+			_nextCbToken = 1
+		gen = _currentGeneration
+		_tokenToGeneration[token] = gen
+		if index is not None:
+			_tokenToIndex[token] = index
+		_generationPending[gen] = _generationPending.get(gen, 0) + 1
+		isPlaying=True
+	ok = wrapperDLL.aisound_speak(text.encode("utf-8"),c_void_p(token))
+	if not ok:
+		shouldNotify=False
+		with _stateLock:
+			failGen = _tokenToGeneration.pop(token, None)
+			_tokenToIndex.pop(token, None)
+			if failGen is not None:
+				remaining = _generationPending.get(failGen, 0)
+				if remaining > 1:
+					_generationPending[failGen] = remaining - 1
+				elif remaining == 1:
+					_generationPending.pop(failGen, None)
+			currentPending = _generationPending.get(_currentGeneration, 0)
+			isPlaying = currentPending > 0
+			shouldNotify = (failGen == _currentGeneration and currentPending == 0)
+		if shouldNotify:
+			synthDoneSpeaking.notify(synth=synthRef())
+	return ok
 
 def Cancel():
-	global wrapperDLL,isPlaying,synthRef
-	isPlaying=False
+	global wrapperDLL,isPlaying,synthRef,_currentGeneration
+	with _stateLock:
+		_currentGeneration += 1
+		_tokenToGeneration.clear()
+		_tokenToIndex.clear()
+		_generationPending.clear()
+		isPlaying=False
 	synthDoneSpeaking.notify(synth=synthRef())
 	return wrapperDLL.aisound_cancel()
 


### PR DESCRIPTION
## Summary of the issue:

Now AiSound5 tracks speech progress with a single global `lastIndex` / `isPlaying` state and passes the speech index directly through `cbData`.
This is fragile when speech requests overlap, when `Cancel` clears playback while native callbacks are still in flight, or when the module is reloaded and `ctypes` callback argument types no longer match exactly.
In these cases, stale `SPEECH_BEGIN` / `SPEECH_END` callbacks can update NVDA state after cancellation, and `waveOutOpen` can fail because equivalent pointer types are rejected by `ctypes`.

## Description of user facing changes:

Users should see more reliable speech state handling from the AiSound synthesizer.
Speech cancellation is less likely to trigger delayed "done speaking" notifications from old utterances, and index notifications should map to the correct queued speech item rather than relying on raw callback data.
The improved `waveOutOpen` hook handling should also reduce failures after reloading the module.

## Description of developer facing changes:

The callback flow now uses explicit callback tokens and generation-based bookkeeping instead of assuming a single active utterance.
This introduces a clearer internal contract:

* each `Speak` call gets a non-zero token
* tokens are mapped to the generation in which they were created
* optional speech indexes are stored separately from callback tokens
* `Cancel` invalidates all prior generations so stale native callbacks are ignored safely

The `waveOutOpen` hook now normalizes incoming pointer arguments to the current `winmm` argtypes before calling back into `ctypes`, which makes the hook more resilient when the module is reloaded.

## Description of development approach

The updated implementation in this pull request makes two targeted technical changes.

First, it replaces the old "single callback payload equals speech index" model with a tokenized callback state machine guarded by `threading.Lock`.
`Speak` allocates a unique non-zero token, records the token's generation and optional index, and increments the pending utterance count for the active generation.
`callback` then resolves `SPEECH_BEGIN` through `_tokenToIndex`, and only sends `synthDoneSpeaking` for `SPEECH_END` when the callback belongs to the current generation and no pending utterances remain.
`Cancel` advances `_currentGeneration` and clears all token maps so late callbacks from the canceled generation are treated as stale and ignored.

Second, the `waveOutOpen` hook now casts `pWaveOutHandle` and `wfx` to the currently registered `windll.winmm.waveOutOpen.argtypes` before invoking the real function.
This is a narrow compatibility fix aimed at avoiding `ctypes` argument-type mismatches after module reloads.

This approach is preferable to simply adding more conditionals around `isPlaying`, because the underlying problem is not a single flag transition.
The implementation needs to distinguish active callbacks from stale callbacks and handle more than one in-flight utterance safely.
Generation-based invalidation gives a deterministic way to drop obsolete native events after `Cancel`, while token-based lookup preserves correct index reporting without overloading the callback pointer value.