### PR TITLE
Bump version to 2026.05

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -23,12 +23,12 @@ addon_info = AddonInfo(
 	# Translators: Long description to be shown for this add-on on add-on information from add-on store
 	addon_description=_("""This is an NVDA speech synthesizer that supports Chinese and requires no other dependencies."""),
 	# version
-	addon_version="25.06",
+	addon_version="2026.05",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
-	addon_changelog=_("""### 25.06
+	addon_changelog=_("""### 2026.05
 
-Bump version."""),
+Bump version, compatible with NVDA 2026.1.0."""),
 	# Author(s)
 	addon_author="NVDA Contributors",
 	# URL for the add-on documentation support
@@ -40,7 +40,7 @@ Bump version."""),
 	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
 	addon_minimumNVDAVersion="2021.1.0",
 	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
-	addon_lastTestedNVDAVersion="2025.1.0",
+	addon_lastTestedNVDAVersion="2026.1.0",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!

--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,3 @@
-Use this file to explain what has changed in your add-on since the previous release. This will be included automatically in the release description when used with GitHub actions.
+### 2026.05
+
+Bump version, compatible with NVDA 2026.1.0.


### PR DESCRIPTION
Bump AiSound5 to 2026.05 and update NVDA last tested compatibility to 2026.1.0. Updates changelog text for the release.